### PR TITLE
Include namePrefix in CRD name of CompositionResourceDefinition

### DIFF
--- a/crossplane-function-springboot-starter/src/main/java/io/crossplane/compositefunctions/starter/registration/CrossplaneCompositeResourceService.java
+++ b/crossplane-function-springboot-starter/src/main/java/io/crossplane/compositefunctions/starter/registration/CrossplaneCompositeResourceService.java
@@ -74,7 +74,6 @@ public class CrossplaneCompositeResourceService {
     public static <T extends CustomResource<?, Void>> CompositeResourceDefinition createCompositeResourceDefinition(T compositionDefinition) { //}, Class functionMixin) {
 
         CompositeResourceDefinition compositeResourceDefinition = new CompositeResourceDefinition();
-        compositeResourceDefinition.setMetadata(CrossplaneMetadataBuilder.createMetadata(compositionDefinition.getCRDName()));
 
         CompositeResourceDefinitionSpec spec = new CompositeResourceDefinitionSpec();
         spec.setGroup(compositionDefinition.getGroup());
@@ -99,10 +98,11 @@ public class CrossplaneCompositeResourceService {
         Versions versions = new Versions();
         versions.setName(compositionDefinition.getVersion());
 
-        // This is not 100%. isStorage vs referencable. Need to check the crossplan docs
+        // This is not 100%. isStorage vs referencable. Need to check the crossplane docs
         versions.setReferenceable(compositionDefinition.isStorage());
         versions.setServed(compositionDefinition.isServed());
 
+        compositeResourceDefinition.setMetadata(CrossplaneMetadataBuilder.createMetadata(namePrefix + compositionDefinition.getCRDName()));
 
         Schema schema = new Schema();
         schema.setOpenAPIV3Schema(getOpenAPIV3Schema(compositionDefinition.getClass(), CrossplaneCompositeResourceMixin.class));

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.1</version>
+        <version>3.3.3</version>
     </parent>
 
     <groupId>io.crossplane.compositefunctions</groupId>
@@ -25,8 +25,8 @@
         <maven.compiler.source>17</maven.compiler.source>
 
         <!-- Dependency versions -->
-        <spring-boot.version>3.3.1</spring-boot.version>
-        <kubernetes-client.version>6.13.0</kubernetes-client.version>
+        <spring-boot.version>3.3.3</spring-boot.version>
+        <kubernetes-client.version>6.13.3</kubernetes-client.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <protobuf.version>3.25.1</protobuf.version>
         <grpc.version>1.63.0</grpc.version>


### PR DESCRIPTION
Logic for adding the `namePrefix` to the CompositionResourceDefinition when the definition calls for a Namespaced object (Claim), should also be included in the CustomResourceDefinition as that requires  the base CRD name to be `plural.group`.

Version updates:
- Spring Boot : 3.3.1 > 3.3.3
- Fabric8 Kubernetes client: 6.13.0 > 6.13.3


